### PR TITLE
showing stderr in case of error exit code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,8 +101,7 @@ export function activate(context: vscode.ExtensionContext) {
       const panel = vscode.window.createWebviewPanel("hurl", "Hurl", vscode.ViewColumn.Beside,{})
       if (error) {
         console.log(`error: ${error.message}`);
-        vscode.window.showErrorMessage(error.message)
-        return;
+        vscode.window.showErrorMessage(convert.toHtml(error.message))
       }
       if (stderr) {
         data += convert.toHtml(stderr)


### PR DESCRIPTION
the return stops having the stderr rendered in vscode, it is useful when
assertion are presents (that makes hurl returning exit code > 0
